### PR TITLE
roles: bgp: add i386_bird feature to save memory

### DIFF
--- a/roles/bgp/tasks/main.yml
+++ b/roles/bgp/tasks/main.yml
@@ -1,8 +1,24 @@
 ---
-- name: Ensure bird is installed
+
+- name: Ensure 32bit/i386 architecture is enabled
+  lineinfile: dest=/var/lib/dpkg/arch line="i386" create=yes
+  register: add_i386
+  when: bgp.i386_bird | default(False)
+  tags: bgp, bird,  bird4, bird6
+
+- name: Ensure bird (32bit/i386) is installed
+  apt:
+    name: bird:i386
+    state: present
+    update_cache: "{{add_i386.changed}}"
+  when: bgp.i386_bird | default(False)
+  tags: bgp, bird,  bird4, bird6
+
+- name: Ensure bird (native) is installed
   apt:
     name: bird
     state: present
+  when: not (bgp.i386_bird | default(False))
   tags: bgp, bird,  bird4, bird6
 
 - name: Ensure common config directory exists


### PR DESCRIPTION
On x86_64 platforms, the 32bit/i386 bird package can be installed via dpkg foreign-architecture in order to save a lot of memory.

Running a 32bit routing daemon limits the maximum memory utilization to ~3GiB, which can be a problem with extremely large setups.

Setting `"bgp": {"i386_bird": true}` activates this feature.

### Real world benefit:
```bash
root@mep1 ~ # uname -m
x86_64

root@mep1 ~ # file /usr/sbin/bird
/usr/sbin/bird: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=a47eaef4910cffb9c24ee95be9884296961b6176, for GNU/Linux 3.2.0, stripped

root@mep1 ~ # birdc show mem
BIRD 1.6.8 ready.
BIRD memory usage
Routing tables:    221 MB
Route attributes:  116 MB
ROA tables:        192  B
Protocols:         737 kB
Total:             337 MB

root@mep1 ~ # birdc6 show mem
BIRD 1.6.8 ready.
BIRD memory usage
Routing tables:     56 MB
Route attributes:   50 MB
ROA tables:        192  B
Protocols:         757 kB
Total:             107 MB

# redeploy with i386_bird: true

root@mep1 ~ # file /usr/sbin/bird
/usr/sbin/bird: ELF 32-bit LSB pie executable, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, BuildID[sha1]=91f9eeef22f3c002e26d3df43de6b9e206be588b, for GNU/Linux 3.2.0, stripped

root@mep1 ~ # birdc show mem
BIRD 1.6.8 ready.
BIRD memory usage
Routing tables:    104 MB
Route attributes:   74 MB
ROA tables:        112  B
Protocols:         243 kB
Total:             178 MB

root@mep1 ~ # birdc6 show mem
BIRD 1.6.8 ready.
BIRD memory usage
Routing tables:     27 MB
Route attributes:   33 MB
ROA tables:        112  B
Protocols:          16 MB
Total:              76 MB
```