### PR TITLE
roles: peering_ibgp: use v6 addr as WG Endpoint when v4 is unavailable

### DIFF
--- a/roles/peering_ibgp/tasks/peering_auto.yml
+++ b/roles/peering_ibgp/tasks/peering_auto.yml
@@ -88,5 +88,5 @@
     wg_peer:
       key: '{{ peer.wireguard.key }}'
       port: '{{ (peername ~ inventory_hostname) | hashnum(peer_port_start, peer_port_end) }}'
-      endpoint: '{% if (peer.wireguard.float | default(False)) %}False{% else %}{{ peer.interfaces.wan.ipv4 | strip_prefixlen }}{% endif %}'
+      endpoint: '{% if (peer.wireguard.float | default(False)) %}False{% else %}{% if (interfaces.wan.ipv4 | default(False)) and (peer.interfaces.wan.ipv4 | default(False)) %}{{ peer.interfaces.wan.ipv4 | strip_prefixlen }}{% else %}[{{ peer.interfaces.wan.ipv6 | strip_prefixlen }}]{% endif %}{% endif %}'
   when: wireguard is defined and peer.wireguard is defined


### PR DESCRIPTION
In pure IPv6 setups, the Wireguard full-mesh currently could not connect to the other hosts in the network.
This commit sets the Wireguard Endpoint accordingly to a IPv6 value on a system without IPv4 connectivity.