### PR TITLE
roles: powerdns: fix invalid IPv4 & IPv6 listening directive

### DIFF
--- a/roles/powerdns/templates/etc/powerdns/pdns.conf.j2
+++ b/roles/powerdns/templates/etc/powerdns/pdns.conf.j2
@@ -1,5 +1,4 @@
-local-address={{ powerdns.listen.ipv4 | default('127.0.0.1') }}
-local-address={{ powerdns.listen.ipv6 | default('::1') }}
+local-address={{ powerdns.listen.ipv4 | default('127.0.0.1') }}, {{ powerdns.listen.ipv6 | default('::1') }}
 version-string=AS{{ asn }}
 geoip-zones-file=/etc/powerdns/zone.yml
 launch=geoip


### PR DESCRIPTION
Previous config set the local_addr directive twice, which overwrote the first one, resulting in a IPv6-only listening server.

New config works as expected:
```bash
root@router ~ # cat /etc/powerdns/pdns.conf
local-address=44.31.126.2, 2a06:e881:5600:5353::
[..]
root@router ~ # ss -tulpen
Netid        State          Recv-Q         Send-Q                           Local Address:Port                  Peer Address:Port        Process
[..]
tcp          LISTEN         0              128                                44.31.126.2:53                         0.0.0.0:*            users:(("pdns_server",pid=2063,fd=7)) uid:110 ino:14160 sk:1003 cgroup:/system.slice/pdns.service <->
tcp          LISTEN         0              128                    [2a06:e881:5600:5353::]:53                            [::]:*            users:(("pdns_server",pid=2063,fd=8)) uid:110 ino:14161 sk:1008 cgroup:/system.slice/pdns.service v6only:1 <->
[..]
```