### PR TITLE
roles: unbound: add whoami. TXT record

### DIFF
--- a/roles/unbound/templates/etc/unbound/unbound.conf
+++ b/roles/unbound/templates/etc/unbound/unbound.conf
@@ -13,6 +13,8 @@ server:
   statistics-interval: 0
   extended-statistics: yes
   statistics-cumulative: no
+  local-zone: "whoami." static
+  local-data: 'whoami. IN TXT "{{ friendly_name }}"'
 
 remote-control:
   control-enable: yes


### PR DESCRIPTION
This change makes unbound resolve the "whoami." record with the hostname of the current node, similar to the PowerDNS authoritative configuration.

```bash
$ dig @resolver.as203478.net +https TXT whoami -4

[..]

;; ANSWER SECTION:
whoami.			3600	IN	TXT	"iwerk"

```