### PR TITLE
roles: unbound: add DNS-over-HTTPS support

### DIFF
--- a/roles/unbound/tasks/unbound.yml
+++ b/roles/unbound/tasks/unbound.yml
@@ -4,6 +4,23 @@
     name: unbound
     state: present
 
+- name: Ensure AppArmor allows access to TLS certificates
+  template:
+    src:  'etc/apparmor.d/local/usr.sbin.unbound'
+    dest: '/etc/apparmor.d/local/usr.sbin.unbound'
+  register: apparmor_config
+  when: unbound.tls_service_key is defined
+
+- name: Ensure AppArmor profile is loaded
+  command: apparmor_parser --replace "/etc/apparmor.d/usr.sbin.unbound"
+  when: apparmor_config.changed
+
+- name: Ensure AppArmor is restarted
+  service:
+    name: 'apparmor'
+    state: 'restarted'
+  when: apparmor_config.changed
+
 - name: Ensure unbound is configured
   template:
     src:  'etc/unbound/unbound.conf'

--- a/roles/unbound/templates/etc/apparmor.d/local/usr.sbin.unbound
+++ b/roles/unbound/templates/etc/apparmor.d/local/usr.sbin.unbound
@@ -1,0 +1,2 @@
+{{ unbound.tls_service_key }} r,
+{{ unbound.tls_service_pem }} r,

--- a/roles/unbound/templates/etc/unbound/unbound.conf
+++ b/roles/unbound/templates/etc/unbound/unbound.conf
@@ -1,7 +1,26 @@
 server:
   directory: "/etc/unbound"
+
+{% if unbound.listen_ipv4 is defined %}
   interface: {{ unbound.listen_ipv4 }}
+{% endif %}
+{% if unbound.listen_ipv6 is defined %}
   interface: {{ unbound.listen_ipv6 }}
+{% endif %}
+
+{% if unbound.listen_https_ipv4 is defined %}
+  interface: {{ unbound.listen_https_ipv4 }}@443
+{% endif %}
+{% if unbound.listen_https_ipv6 is defined %}
+  interface: {{ unbound.listen_https_ipv6 }}@443
+{% endif %}
+{% if unbound.tls_service_key is defined %}
+  tls-service-key: "{{ unbound.tls_service_key }}"
+{% endif %}
+{% if unbound.tls_service_pem is defined %}
+  tls-service-pem: "{{ unbound.tls_service_pem }}"
+{% endif %}
+
   outgoing-interface: {{ addresses['as' + (asn | string)].ipv4 | strip_prefixlen }}
   outgoing-interface: {{ addresses['as' + (asn | string)].ipv6 | strip_prefixlen }}
   access-control: 0.0.0.0/0 allow


### PR DESCRIPTION
This change adds DNS-over-HTTPS support with Unbound directly,
it adds new listen_https_ipv4/listen_https_ipv6 parameters and requires
tls_service_key/tls_service_pem to be set with paths to TLS certificates

```bash
$ dig @resolver.as203478.net +https AAAA kittenlabs.de

; <<>> DiG 9.20.7 <<>> @resolver.as203478.net +https AAAA kittenlabs.de
; (2 servers found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49953
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;kittenlabs.de.			IN	AAAA

;; ANSWER SECTION:
kittenlabs.de.		900	IN	AAAA	2a01:4f8:212:2e07::81

;; Query time: 63 msec
;; SERVER: 2a06:e881:5600:53::4#443(resolver.as203478.net) (HTTPS)
;; WHEN: Thu Apr 03 16:59:42 CEST 2025
;; MSG SIZE  rcvd: 70

```