### PR TITLE
roles: unbound: generate control socket certificates

### DIFF
--- a/roles/unbound/tasks/unbound.yml
+++ b/roles/unbound/tasks/unbound.yml
@@ -3,6 +3,11 @@
   apt:
     name: unbound
     state: present
+  
+- name: Ensure unbound control socket certificates exist 
+  command: unbound-control-setup
+  args: 
+    creates: /etc/unbound/unbound_server.pem
 
 - name: Ensure unbound is configured
   template:


### PR DESCRIPTION
In the Debian 11 to 12 migration, unbound gained an authenticated control socket. This socket needs a certificate/key pair to work and the upgrade process doesn't seem to run the initial generation.

This change runs `unbound-control-setup` if the certificate file isn't present on the system yet.