### PR TITLE
roles: peering_ibgp: enable "next hop self" for ibgp peerings

### DIFF
--- a/roles/peering_ibgp/templates/etc/bird/bird4/peers/ibgp-{{ friendly_name }}.conf.j2
+++ b/roles/peering_ibgp/templates/etc/bird/bird4/peers/ibgp-{{ friendly_name }}.conf.j2
@@ -2,6 +2,7 @@ protocol bgp '{{ friendly_name }}' from bgp_internal {
   neighbor {{ peer_address }} as OWN_AS;
   gateway direct;
   direct;
+  next hop self;
 {% if rr_role == "client" %}
   rr client;
 {% endif %}

--- a/roles/peering_ibgp/templates/etc/bird/bird6/peers/ibgp-{{ friendly_name }}.conf.j2
+++ b/roles/peering_ibgp/templates/etc/bird/bird6/peers/ibgp-{{ friendly_name }}.conf.j2
@@ -2,6 +2,7 @@ protocol bgp '{{ friendly_name }}' from bgp_internal {
   neighbor {{ peer_address }}%'{{ peer_interface }}' as OWN_AS;
   gateway direct;
   direct;
+  next hop self;
 {% if rr_role == "client" %}
   rr client;
 {%- endif %}


### PR DESCRIPTION
Bird 2 will not accept routes via IBGP with the original next hop, traditionally being set to the original next hop, not the IBGP neighbor.

Bird 1 would fix-up such routes internally and use the BGP neighbor address instead. Bird 2 just ignores the routes.

As a compatibility measure, enable "next hop self" to announce the correct next hop via BGP.