### PR TITLE
roles: bgp/peering_ibgp/peerings_direct: add BFD support

### DIFF
--- a/roles/bgp/files/etc/bird/protocols/010-system.conf
+++ b/roles/bgp/files/etc/bird/protocols/010-system.conf
@@ -2,6 +2,13 @@ protocol device {
   scan time 10;
 };
 
+protocol bfd {
+  interface "*" {
+    interval 500ms;
+    multiplier 5;
+  };
+};
+
 protocol kernel 'fulltable_v4' {
   kernel table OWN_AS;
   ipv4 {

--- a/roles/bgp/templates/etc/bird/protocols/020-templates.conf.j2
+++ b/roles/bgp/templates/etc/bird/protocols/020-templates.conf.j2
@@ -52,6 +52,7 @@ template bgp 'bgp_upstream_transitive' {
 
 template bgp 'bgp_internal' {
   local as OWN_AS;
+  bfd graceful;
 {% if bgp.route_reflection is defined and bgp.route_reflection %}
   {%- if bgp.route_reflection == 'off' %}
   {# Same as false and not defined, don't do anything #}

--- a/roles/peering_ibgp/templates/etc/iptables.d/500-allow-BGP4-ibgp-{{ peername }}.conf.j2
+++ b/roles/peering_ibgp/templates/etc/iptables.d/500-allow-BGP4-ibgp-{{ peername }}.conf.j2
@@ -1,2 +1,5 @@
 # Allow incoming BGP connections from {{ peername }} via IPv4
 ip4tables -A INPUT -p tcp --dport 179 -i {{ wg_iface }} -s {{ ipv4_address_peer | strip_prefixlen }}/32 -j ACCEPT -m comment --comment "Accept BGP from {{ peername }}"
+# Allow incoming BFD connections from {{ peername }} via IPv4
+ip4tables -A INPUT --dport 3784 -i {{ wg_iface }} -s {{ ipv4_address_peer | strip_prefixlen }}/32 -j ACCEPT -m comment --comment "Accept BFD from {{ peername }}"
+ip4tables -A INPUT --dport 4784 -i {{ wg_iface }} -s {{ ipv4_address_peer | strip_prefixlen }}/32 -j ACCEPT -m comment --comment "Accept BFD multi-hop from {{ peername }}"

--- a/roles/peering_ibgp/templates/etc/iptables.d/500-allow-BGP6-ibgp-{{ peername }}.conf.j2
+++ b/roles/peering_ibgp/templates/etc/iptables.d/500-allow-BGP6-ibgp-{{ peername }}.conf.j2
@@ -1,2 +1,5 @@
 # Allow incoming BGP connections from {{ peername }} via IPv6
 ip6tables -A INPUT -p tcp --dport 179 -i {{ wg_iface }} -s {{ ipv6_address_peer | strip_prefixlen }}/128 -j ACCEPT -m comment --comment "Accept BGP from {{ peername }}"
+# Allow incoming BFD connections from {{ peername }} via IPv6
+ip6tables -A INPUT --dport 3784 -i {{ wg_iface }} -s {{ ipv6_address_peer | strip_prefixlen }}/128 -j ACCEPT -m comment --comment "Accept BFD from {{ peername }}"
+ip6tables -A INPUT --dport 4784 -i {{ wg_iface }} -s {{ ipv6_address_peer | strip_prefixlen }}/128 -j ACCEPT -m comment --comment "Accept BFD multi-hop from {{ peername }}"

--- a/roles/peerings_direct/templates/etc/bird/peers/direct-{{ peername }}-v4.conf.j2
+++ b/roles/peerings_direct/templates/etc/bird/peers/direct-{{ peername }}-v4.conf.j2
@@ -5,6 +5,9 @@ protocol bgp '{{ peername }}_v4' from bgp_{{ peering_type }} {
 {% if peering.password is defined %}
   password "{{ peering.password }}";
 {% endif %}
+{% if peering.bfd is defined %}
+  bfd graceful;
+{% endif %}
 {% set res_var_suffix = peername | regex_replace('[^a-zA-Z0-9_]', '_') %}
   ipv4 {
   {% if peering.filter.import is defined %}

--- a/roles/peerings_direct/templates/etc/bird/peers/direct-{{ peername }}-v6.conf.j2
+++ b/roles/peerings_direct/templates/etc/bird/peers/direct-{{ peername }}-v6.conf.j2
@@ -7,6 +7,9 @@ protocol bgp '{{ peername }}_v6' from bgp_{{ peering_type }} {
 {% if peering.password is defined %}
   password "{{ peering.password }}";
 {% endif %}
+{% if peering.bfd is defined %}
+  bfd graceful;
+{% endif %}
 {% set res_var_suffix = peername | regex_replace('[^a-zA-Z0-9_]', '_') %}
   ipv6 {
   {% if peering.filter.import is defined %}

--- a/roles/peerings_direct/templates/etc/iptables.d/500-allow-BGP4-peering-{{ peername }}.conf.j2
+++ b/roles/peerings_direct/templates/etc/iptables.d/500-allow-BGP4-peering-{{ peername }}.conf.j2
@@ -1,2 +1,5 @@
 # Allow incoming BGP connections from {{ peername }} via IPv4
 ip4tables -A INPUT -p tcp --dport 179 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv4 }}/32 -j ACCEPT -m comment --comment "Accept BGP from {{ peername }}"
+# Allow incoming BFD connections from {{ peername }} via IPv4
+ip4tables -A INPUT --dport 3784 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv4 }}/32 -j ACCEPT -m comment --comment "Accept BFD from {{ peername }}"
+ip4tables -A INPUT --dport 4784 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv4 }}/32 -j ACCEPT -m comment --comment "Accept BFD multi-hop from {{ peername }}"

--- a/roles/peerings_direct/templates/etc/iptables.d/500-allow-BGP6-peering-{{ peername }}.conf.j2
+++ b/roles/peerings_direct/templates/etc/iptables.d/500-allow-BGP6-peering-{{ peername }}.conf.j2
@@ -1,2 +1,5 @@
 # Allow incoming BGP connections from {{ peername }} via IPv6
 ip6tables -A INPUT -p tcp --dport 179 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/32 -j ACCEPT -m comment --comment "Accept BGP from {{ peername }}"
+# Allow incoming BFD connections from {{ peername }} via IPv6
+ip6tables -A INPUT --dport 3784 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/128 -j ACCEPT -m comment --comment "Accept BFD from {{ peername }}"
+ip6tables -A INPUT --dport 4784 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/128 -j ACCEPT -m comment --comment "Accept BFD multi-hop from {{ peername }}"

--- a/roles/peerings_direct/templates/etc/iptables.d/500-allow-BGP6-peering-{{ peername }}.conf.j2
+++ b/roles/peerings_direct/templates/etc/iptables.d/500-allow-BGP6-peering-{{ peername }}.conf.j2
@@ -1,5 +1,5 @@
 # Allow incoming BGP connections from {{ peername }} via IPv6
-ip6tables -A INPUT -p tcp --dport 179 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/32 -j ACCEPT -m comment --comment "Accept BGP from {{ peername }}"
+ip6tables -A INPUT -p tcp --dport 179 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/128 -j ACCEPT -m comment --comment "Accept BGP from {{ peername }}"
 # Allow incoming BFD connections from {{ peername }} via IPv6
 ip6tables -A INPUT --dport 3784 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/128 -j ACCEPT -m comment --comment "Accept BFD from {{ peername }}"
 ip6tables -A INPUT --dport 4784 -i {{ peering.self.ifname }} -s {{ peering.peer.ipv6 }}/128 -j ACCEPT -m comment --comment "Accept BFD multi-hop from {{ peername }}"


### PR DESCRIPTION
This change adds BFD support for much faster detection of lost links.
It enables BFD by default for internal peerings and adds the new
"bfd" flag for manual peering configurations.

Fixes #31